### PR TITLE
Adding EZSPv8 support

### DIFF
--- a/src/ezsp/ashv2-codec.cpp
+++ b/src/ezsp/ashv2-codec.cpp
@@ -97,16 +97,11 @@ NSSPI::ByteBuffer AshCodec::forgeAckFrame(void) {
 NSSPI::ByteBuffer AshCodec::forgeDataFrame(NSSPI::ByteBuffer i_data) {
 	NSSPI::ByteBuffer lo_msg;
 
-	/*
-	clogD << "Going to send ASH message, encoding EZSP message (seq=" << +(static_cast<unsigned char>(seq_num))
-	      << ", " << +(static_cast<unsigned char>(frmNum))
-	      << ", FC=0): " << NSSPI::Logger::byteSequenceToString(li_data) << "\n"; // Note FC is hardcoded to 0 below
-	*/
-
 	uint8_t ashControlByte = static_cast<uint8_t>(this->frmNum << 4) | (this->lastReceivedByNEAckNum & 0x07U);
 	lo_msg.push_back(ashControlByte);
 	//clogD << "AshCodec creating DATA(frmNum=" << std::dec << static_cast<unsigned int>(u8_get_hi_nibble(ashControlByte) & 0x07U)
 	//      << ", ackNum=" << static_cast<unsigned int>(u8_get_lo_nibble(ashControlByte) & 0x07U) << ")\n";
+	//clogD << "EZSP payload: " << NSSPI::Logger::byteSequenceToString(i_data) << "\n";
 	this->frmNum++;
 	this->frmNum &= 0x07U;
 	this->nextExpectedFEAckNum = this->frmNum;	/* ACK value always contain the next expected frame number */

--- a/src/ezsp/ezsp-dongle.h
+++ b/src/ezsp/ezsp-dongle.h
@@ -203,6 +203,32 @@ private:
      */
     void handleDongleState( EDongleState i_state );
     void handleResponse( EEzspCmd i_cmd );
+
+protected:
+    /**
+     * @brief Check if we know which EZSP protocol version is used by the EZSP adapter
+     * 
+     * @return true if we know the EZSP protocol version
+     */
+    bool knownEzspProtocolVersion() const;
+
+    /**
+     * @brief Check if the EZSP protocol version used by the EZSP adapter is greater or equal to a minimum value
+     * 
+     * @param minIncludedVersion Minimum acceptable version (version should be greater or equal to that value)
+     * 
+     * @return true if the EZSP protocol version matches the requirement
+     */
+    bool knownEzspProtocolVersionGE(uint8_t minIncludedVersion) const;
+
+    /**
+     * @brief Check if the EZSP protocol version used by the EZSP adapter is strictly lower than a maximum value
+     * 
+     * @param maxExcludedVersion Maximum acceptable version (version should be strictly lower than that value, not equal)
+     * 
+     * @return true if the EZSP protocol version matches the requirement
+     */
+    bool knownEzspProtocolVersionLT(uint8_t maxExcludedVersion) const;
 };
 
 } // namespace NSEZSP

--- a/src/ezsp/lib-ezsp-main.cpp
+++ b/src/ezsp/lib-ezsp-main.cpp
@@ -24,7 +24,7 @@ CLibEzspMain::CLibEzspMain(NSSPI::IUartDriverHandle uartHandle, const NSSPI::Tim
     uartHandle(uartHandle),
     timerbuilder(timerbuilder),
     exp_ezsp_min_version(6),    /* Expect EZSP version 6 minimum */
-    exp_ezsp_max_version(7),    /* Expect EZSP version 7 maximum */
+    exp_ezsp_max_version(8),    /* Expect EZSP version 8 maximum */
     exp_stack_type(2),  /* Expect a stack type=2 (mesh) */
     xncpManufacturerId(0),  /* 0 means unknown (yet) */
     xncpVersionNumber(0),  /* 0 means unknown (yet) */
@@ -425,12 +425,19 @@ void CLibEzspMain::handleEzspRxMessage_VERSION(const NSSPI::ByteBuffer& i_msg_re
 			clogE << "Stopping init here. Library will not work with this EZSP adapter\n";
 			return;
 		}
-		if (ezspProtocolVersion > this->exp_ezsp_min_version || ezspProtocolVersion <= this->exp_ezsp_max_version) {
-			clogD << "Current EZSP version supported by dongle (" << static_cast<int>(ezspProtocolVersion) << ") is higher than our minimum (" << static_cast<int>(exp_ezsp_min_version) << "). Re-initializing dongle\n";
-			this->exp_ezsp_min_version = ezspProtocolVersion;
-			acceptableVersion = false;
-			dongleInit(this->exp_ezsp_min_version);
-			return;
+		if (ezspProtocolVersion > this->exp_ezsp_min_version) {
+			if (ezspProtocolVersion > this->exp_ezsp_max_version) {
+				clogE << "Unsupported EZSP version (v" << std::dec << static_cast<int>(ezspProtocolVersion) << " is too high for this library)\n";
+				acceptableVersion = false;
+				return;
+			}
+			else {
+				clogD << "Current EZSP version supported by dongle (" << std::dec << static_cast<int>(ezspProtocolVersion) << ") is higher than our minimum (" << static_cast<int>(exp_ezsp_min_version) << "). Re-initializing dongle\n";
+				this->exp_ezsp_min_version = ezspProtocolVersion;
+				acceptableVersion = false;
+				dongleInit(this->exp_ezsp_min_version);
+				return;
+			}
 		}
 		else if (ezspProtocolVersion == this->exp_ezsp_min_version &&  ezspProtocolVersion <= this->exp_ezsp_max_version) {
 			acceptableVersion = true;


### PR DESCRIPTION
Implementing EZSPv8 support based on EZSP protocol version returned by adapter in the EZSP_VERSION response from the adapter at startup.
Both EZSPv{6,7} and EZSPv8 are supported simultaneously.
Switch-over from one to the other is done just after the EZSP_VERSION notification.